### PR TITLE
Add global style helper

### DIFF
--- a/pages/1_Welcome.py
+++ b/pages/1_Welcome.py
@@ -1,6 +1,9 @@
 import streamlit as st
+import utils
 
 st.set_page_config(layout="wide")
+
+utils.inject_global_css()
 
 st.title("Welcome")
 

--- a/pages/2_Data_and_Hypotheses.py
+++ b/pages/2_Data_and_Hypotheses.py
@@ -19,6 +19,8 @@ from instructions import data_summary_instructions
 
 st.set_page_config(layout="wide")
 
+utils.inject_global_css()
+
 load_dotenv()
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 

--- a/pages/3_Analysis_Plan.py
+++ b/pages/3_Analysis_Plan.py
@@ -49,6 +49,8 @@ import re
 load_dotenv()
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
+utils.inject_global_css()
+
 
 # ───────────────────────── guards ───────────────────────────
 if "analyses" not in st.session_state or not st.session_state["analyses"]:

--- a/pages/4_Final_Report.py
+++ b/pages/4_Final_Report.py
@@ -1,6 +1,7 @@
 # pages/4_Final_Report.py
 import streamlit as st
 import openai
+import utils
 
 from utils import (
     create_code_interpreter_tool, 
@@ -13,6 +14,8 @@ from utils import (
 from instructions import report_generation_instructions, report_chat_instructions
 
 from st_copy import copy_button
+
+utils.inject_global_css()
 
 # ───────────────────────── guards ────────────────────────────────
 if "analyses" not in st.session_state or not st.session_state["analyses"]:

--- a/utils.py
+++ b/utils.py
@@ -31,6 +31,33 @@ from openai.types.responses.response_output_text import AnnotationContainerFileC
 load_dotenv()
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
+
+def inject_global_css() -> None:
+    """Inject shared CSS to normalise headers and sidebar font sizes."""
+    st.markdown(
+        """
+        <style>
+            h1, h2, h3, h4 {
+                margin-top: 0.3rem;
+                margin-bottom: 0.3rem;
+            }
+
+            [data-testid="stSidebar"] h1,
+            [data-testid="stSidebar"] h2,
+            [data-testid="stSidebar"] h3,
+            [data-testid="stSidebar"] h4 {
+                font-size: 1rem;
+            }
+
+            [data-testid="stSidebar"] li,
+            [data-testid="stSidebar"] p {
+                font-size: 0.9rem;
+            }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
 def to_mock_chunks(resp: Response) -> List[Chunk]:
     """
     Convert an `openai.Response` into the mock-LLM chunk list:


### PR DESCRIPTION
## Summary
- add shared CSS injection function for consistent headers and sidebar fonts
- call the style helper across all pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625f319e50832db043eb2722ae9b5c