### PR TITLE
Enhance final report display

### DIFF
--- a/pages/4_Final_Report.py
+++ b/pages/4_Final_Report.py
@@ -210,6 +210,12 @@ with main_col:
         st.markdown("## Final report")
         print(f"\n\nFINAL REPORT: {st.session_state['final_report']}")
 
+        # Display the report inside a light grey container
+        st.markdown(
+            "<div style='background-color:#f0f0f0; padding:1em; border-radius:10px;'>",
+            unsafe_allow_html=True,
+        )
+
         new_chunks = explode_text_and_images(st.session_state["final_report"])
 
         for chunk in new_chunks:
@@ -222,6 +228,8 @@ with main_col:
                     st.image(image_to_display)
                 else:
                     st.warning(f"Image with {image_id} not found. Available images are: ")
+
+        st.markdown("</div>", unsafe_allow_html=True)
 
         wide, narrow = st.columns([95,5])
         


### PR DESCRIPTION
## Summary
- wrap final report in a light gray HTML container for better separation from the discussion chat

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b95fe714832d9800cb23f7d53d5d